### PR TITLE
Add player/enemy melee hitbox and back multi vector visualization

### DIFF
--- a/EnemyHitboxView/EntryPoint.cs
+++ b/EnemyHitboxView/EntryPoint.cs
@@ -499,10 +499,12 @@ namespace EnemyHitboxView
         public void Start()
         {
             GameObject leftGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            leftGO.GetComponent<Collider>().enabled = false;
             left = leftGO.GetComponent<Renderer>();
             left.material.color = Color.red;
             left.transform.position = Vector3.zero;
             GameObject rightGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            rightGO.GetComponent<Collider>().enabled = false;
             right = rightGO.GetComponent<Renderer>();
             right.material.color = Color.red;
             right.transform.position = Vector3.zero;

--- a/EnemyHitboxView/EntryPoint.cs
+++ b/EnemyHitboxView/EntryPoint.cs
@@ -9,6 +9,7 @@ using Il2CppInterop.Runtime.Injection;
 using CConsole.Interop;
 using Il2CppInterop.Runtime.InteropTypes;
 using FluffyUnderware.DevTools.Extensions;
+using Gear;
 
 namespace EnemyHitboxView
 {
@@ -25,6 +26,7 @@ namespace EnemyHitboxView
             ClassInjector.RegisterTypeInIl2Cpp<EnemyHitboxCuller>();
             ClassInjector.RegisterTypeInIl2Cpp<EnemyMeleeHitboxes>();
             ClassInjector.RegisterTypeInIl2Cpp<EnemyBackMulti>();
+            ClassInjector.RegisterTypeInIl2Cpp<PlayerMeleeHitboxes>();
 
             _Harmony = new Harmony($"{VersionInfo.RootNamespace}.Harmony");
             _Harmony.PatchAll();
@@ -84,6 +86,24 @@ namespace EnemyHitboxView
                 context.Log($"DisplayEnemyMeleeHitboxes: {EnemyMeleeHitboxes.ShowHitboxes}");
             }
             );
+            CustomCommands.Register(new()
+            {
+                Command = "DisplayPlayerMeleeHitboxes",
+                Description = "Show spheres to mark player's melee hitboxes.",
+                Usage = "DisplayPlayerMeleeHitboxes [true/false]",
+                Category = CConsole.Commands.CategoryType.LocalPlayer,
+                MinArgumentCount = 0
+            },
+            (in CustomCmdContext context, string[] args) =>
+            {
+                if (args.Length > 0 && bool.TryParse(args[0], out bool result))
+                    PlayerMeleeHitboxes.ShowHitboxes = result;
+                else
+                    PlayerMeleeHitboxes.ShowHitboxes ^= true; // toggle
+
+                context.Log($"DisplayPlayerMeleeHitboxes: {PlayerMeleeHitboxes.ShowHitboxes}");
+            }
+            );
         }
 
         public override bool Unload()
@@ -140,6 +160,14 @@ namespace EnemyHitboxView
         {
             if (__instance.m_agent.gameObject.GetComponent<EnemyBackMulti>() == null)
                 __instance.m_agent.gameObject.AddComponent<EnemyBackMulti>().enemy = __instance.m_agent;
+        }
+
+        [HarmonyPatch(typeof(MeleeWeaponFirstPerson), nameof(MeleeWeaponFirstPerson.Setup))]
+        [HarmonyPostfix]
+        public static void MWFPSetup_Patch(MeleeWeaponFirstPerson __instance)
+        {
+            if (__instance.gameObject.GetComponent<PlayerMeleeHitboxes>() == null)
+                __instance.gameObject.AddComponent<PlayerMeleeHitboxes>().melee = __instance;
         }
     }
 
@@ -514,6 +542,51 @@ namespace EnemyHitboxView
         }
     }
 
+    internal class PlayerMeleeHitboxes : MonoBehaviour
+    {
+        public static bool ShowHitboxes = false;
+
+        public MeleeWeaponFirstPerson melee;
+        public Renderer meleeHitbox;
+
+        public void Start()
+        {
+            GameObject meleeHitboxGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            meleeHitboxGO.GetComponent<Collider>().enabled = false;
+            meleeHitbox = meleeHitboxGO.GetComponent<Renderer>();
+            meleeHitbox.material.color = Color.white;
+            meleeHitbox.transform.position = Vector3.zero;
+        }
+
+        public void OnDestroy()
+        {
+            if (meleeHitbox != null)
+                meleeHitbox.gameObject.Destroy();
+        }
+
+        public void Update()
+        {
+            if (melee == null || meleeHitbox == null)
+                return;
+
+            // Find out if we are currently meleeing.
+            bool currentlyMeleeing = true;
+            if (!ShowHitboxes || !currentlyMeleeing)
+            {
+                meleeHitbox.enabled = false;
+                return;
+            }
+
+            meleeHitbox.enabled = true;
+            float radius = melee.MeleeArchetypeData.AttackSphereRadius;
+            // Check if the radius is getting enlarged for reasons.
+            float inFront = Vector3.Dot(melee.Owner.FPSCamera.Forward, (melee.ModelData.m_damageRefAttack.position - melee.Owner.FPSCamera.Position).normalized);
+            if (inFront > 0.5)
+                radius *= 1f + inFront * melee.m_attackDamageSphereDotScale;
+            meleeHitbox.transform.localScale = new Vector3(radius, radius, radius);
+            meleeHitbox.transform.position = melee.ModelData.m_damageRefAttack.position;
+        }
+    }
     static class Extension
     {
         public static bool TryCastAtHome<T, O>(this T InComp, out O OutComp)

--- a/EnemyHitboxView/EntryPoint.cs
+++ b/EnemyHitboxView/EntryPoint.cs
@@ -118,7 +118,7 @@ namespace EnemyHitboxView
     {
         [HarmonyPatch(typeof(EnemyAgent), nameof(EnemyAgent.Setup))]
         [HarmonyPostfix]
-        public static void EASetup_Patch(EnemyAgent __instance)
+        public static void Setup_Patch(EnemyAgent __instance)
         {
             foreach (var limb in __instance.Damage.DamageLimbs)
             {
@@ -140,26 +140,15 @@ namespace EnemyHitboxView
                 hitbox.Setup(limb, collider);
             }
 
-            // Add a monobehaviour to the EnemyAgent to turn its renderers on and off 
+            // Add a monobehaviour to the EnemyAgent to turn its hitbox renderers on and off.
             if (__instance.gameObject.GetComponent<EnemyHitboxCuller>() == null)
                 __instance.gameObject.AddComponent<EnemyHitboxCuller>();
-        }
-
-        // This could possibly be included into the above `EASetup_Patch` method.
-        [HarmonyPatch(typeof(EnemyLocomotion), nameof(EnemyLocomotion.Setup))]
-        [HarmonyPostfix]
-        public static void ELSetup_Patch(EnemyLocomotion __instance)
-        {
-            if (__instance.m_agent.gameObject.GetComponent<EnemyMeleeHitboxes>() == null)
-                __instance.m_agent.gameObject.AddComponent<EnemyMeleeHitboxes>().enemy = __instance.m_agent;
-        }
-
-        [HarmonyPatch(typeof(EnemySync), nameof(EnemySync.OnSpawn))]
-        [HarmonyPostfix]
-        public static void ESOnSpawn_Patch(EnemySync __instance)
-        {
-            if (__instance.m_agent.gameObject.GetComponent<EnemyBackMulti>() == null)
-                __instance.m_agent.gameObject.AddComponent<EnemyBackMulti>().enemy = __instance.m_agent;
+            // And one for its back multi vectors:
+            if (__instance.gameObject.GetComponent<EnemyBackMulti>() == null)
+                __instance.gameObject.AddComponent<EnemyBackMulti>().enemy = __instance;
+            // And one for its melee hitboxes:
+            if (__instance.gameObject.GetComponent<EnemyMeleeHitboxes>() == null)
+                __instance.gameObject.AddComponent<EnemyMeleeHitboxes>().enemy = __instance;
         }
 
         [HarmonyPatch(typeof(MeleeWeaponFirstPerson), nameof(MeleeWeaponFirstPerson.Setup))]


### PR DESCRIPTION
Adds 3 new commands:
- `DisplayEnemyBackMulti`
- `DisplayEnemyMeleeHitboxes`
- `DisplayPlayerMeleeHitboxes`

which all do exactly what you'd guess.

I ended up only implementing the vector part of the back multi stuff (the text popup was a bit much for my purposes).

I also mostly implemented the other two commands in the same fashion as randomuserhi used for the back multi vectors (I spent a while understanding how it was done so I just repeated it with tweaks). This might mean there's some stuff from your `DisplayEnemyHitboxes` code that could have been reused, but it looked like it'd require some kinda refactor and that just seemed a bit much for a smaller-scale mod like this.